### PR TITLE
feat(orders): esquema SQL y script de creación de pedido

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+*.log
+.env
+.DS_Store

--- a/app/create_order.php 
+++ b/app/create_order.php 
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Crea un pedido de ejemplo con ítems asociados (IACC, 2025).
+ * Flujo pensado para revisión vía Pull Request (Cardellino, 2021; GitHub, 2024; codigofacilito, 2021).
+ */
+try {
+    // ⚠️ Cambia TU_PASSWORD por tu contraseña real de MySQL
+    $pdo = new PDO("mysql:host=localhost;dbname=ecommerce", "root", "Resp..2025");
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    // Crear pedido (Cardellino, 2021)
+    $stmt = $pdo->prepare("INSERT INTO orders (customer_name) VALUES (:customer)");
+    $stmt->execute([':customer' => 'Cliente Demo']);
+    $orderId = $pdo->lastInsertId();
+
+    // Ítems: 1x Ruta (id 1), 2x Ruedas (id 3) (IACC, 2025)
+    $pdo->exec("INSERT INTO order_items (order_id, product_id, quantity) VALUES ($orderId, 1, 1)");
+    $pdo->exec("INSERT INTO order_items (order_id, product_id, quantity) VALUES ($orderId, 3, 2)");
+
+    echo "Pedido creado con ID: $orderId\n";
+} catch (PDOException $e) {
+    echo "Error DB: " . $e->getMessage() . "\n";
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,36 @@
+-- Esquema para e-commerce de bicicletas (IACC, 2025)
+CREATE DATABASE IF NOT EXISTS ecommerce;
+USE ecommerce;
+
+-- Tabla de productos (IACC, 2025)
+CREATE TABLE IF NOT EXISTS products (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  stock INT NOT NULL
+);
+
+-- Tabla de pedidos (IACC, 2025)
+CREATE TABLE IF NOT EXISTS orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  customer_name VARCHAR(100) NOT NULL,
+  order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tabla de ítems de pedido (IACC, 2025)
+CREATE TABLE IF NOT EXISTS order_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  order_id INT,
+  product_id INT,
+  quantity INT,
+  FOREIGN KEY (order_id) REFERENCES orders(id),
+  FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+-- Productos de ciclismo (IACC, 2025)
+INSERT INTO products (name, price, stock) VALUES
+('Bicicleta de Ruta', 1200000, 5),
+('Bicicleta Mountain Bike', 950000, 3),
+('Ruedas de Carbono', 450000, 10),
+('Casco Aero', 120000, 15),
+('Zapatillas Ciclismo', 90000, 20);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,3 +1,4 @@
+-- Demo en video: commit de colaboración
 -- Esquema para e-commerce de bicicletas (IACC, 2025)
 CREATE DATABASE IF NOT EXISTS ecommerce;
 USE ecommerce;


### PR DESCRIPTION
Alcance: agrega tablas (products, orders, order_items) y un script PHP para crear un pedido de ejemplo.
Pruebas: ejecutar db/schema.sql en MySQL Workbench y luego php app/create_order.php.
Buenas prácticas: trabajo por ramas, revisión de código vía PR y mensajes de commit claros (Cardellino, 2021; GitHub, 2024; IACC, 2025).